### PR TITLE
Improve the handling of query errors.

### DIFF
--- a/entsoe_client/Parsers/Acknowledgment_MarketDocument_Parser.py
+++ b/entsoe_client/Parsers/Acknowledgment_MarketDocument_Parser.py
@@ -1,0 +1,45 @@
+from entsoe_client.Parsers import ParserUtils as utils
+from entsoe_client.Parsers.Entsoe_Document_Parser import Entsoe_Document_Parser
+
+class Abstract_Acknowledgment_MarketDocument_Parser(Entsoe_Document_Parser):
+    def __init__(self):
+        super().__init__()
+        self.Document_Parser = None
+        self.TimeSeries_Parser = None
+        self.Series_Period_Parser = None
+        self.Point_Parser = None
+        self.MktPSRType_Parser = None
+        self.MktGeneratingUnit_Parser = None
+
+    def set_Document_Parser(self, Document_Parser):
+        self.Document_Parser = Document_Parser
+
+    def set_TimeSeries_Parser(self, TimeSeries_Parser):
+        self.TimeSeries_Parser = TimeSeries_Parser
+
+    def set_Series_Period_Parser(self, Series_Period_Parser):
+        self.Series_Period_Parser = Series_Period_Parser
+
+    def set_Point_Parser(self, Point_Parser):
+        self.Point_Parser = Point_Parser
+
+    def set_MktPSRType_Parser(self, MktPSRType_Parser):
+        self.MktPSRType_Parser = MktPSRType_Parser
+
+    def set_MktGeneratingUnit_Parser(self, MktGeneratingUnit_Parser):
+        self.MktGeneratingUnit_Parser = MktGeneratingUnit_Parser
+
+
+class Acknowledgment_MarketDocument_Parser(Abstract_Acknowledgment_MarketDocument_Parser):
+    def __init__(self):
+        super(Acknowledgment_MarketDocument_Parser, self).__init__()
+        self.set_Document_Parser(utils.StandardErrorDocumentParser)
+
+    def parse(self):
+        df = self.Document_Parser(self.objectified_input_xml)
+        # Make it easier for the user to read the error message by shuffling it to the top
+        index = [df.index[0], df.index[-1], df.index[-2]]
+        index.extend(df.index[1:-2])
+        df = df.reindex(index=index)
+
+        return df

--- a/entsoe_client/Parsers/ParserUtils.py
+++ b/entsoe_client/Parsers/ParserUtils.py
@@ -62,6 +62,12 @@ class Tree_to_DataFrame:
         df = df.assign(**meta_dict)
         return df
 
+def Root_to_DataFrame_fn() -> Callable:
+    def Root_to_DataFrame(Root: etree._Element) -> pd.DataFrame:
+        data = [ (elem.tag, elem.text) for elem in Root.getiterator() ]
+        return pd.DataFrame(data, columns=['Tag', 'Value'])
+
+    return Root_to_DataFrame
 
 def Period_to_DataFrame_fn(get_Period_data: Callable) -> Callable:
     def Period_to_DataFrame(Period: etree._Element) -> pd.DataFrame:
@@ -146,3 +152,4 @@ def get_Point_Financial_Price_data(Point: etree._Element) -> Dict:
 
 
 StandardPeriodParser = Period_to_DataFrame_fn(get_Period_data)
+StandardErrorDocumentParser = Root_to_DataFrame_fn()


### PR DESCRIPTION
If the ENTSO-E API cannot fulfil a request, for example because the date range exceeds the limit, it will return an XML file which contains the reason for the denied request. The proposed changes will parse the XML and return a DataFrame containing the error message.

Running

```
query = ec.Query(
    documentType=pt.DocumentType("Accepted offers"),
    businessType=pt.BusinessType("Automatic frequency restoration reserve"),
    controlArea_Domain=pt.Area("SE_1"),
    periodStart="2022-01-01T00:00",
    periodEnd="2023-05-02T00:00"
)

response = client(query)
df = parser.parse(response)

df.head()
```

produces
<img width="613" alt="image" src="https://github.com/DarioHett/entsoe-client/assets/11620064/7765e809-ac44-4035-a5ac-7b2b22756bcd">


And also, thank you for this wonderful library!