### PR TITLE
Added the 'Outages' (Excluded 10.1.C) parser, bumped version of pytz.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .env
 settings.py
+venv

--- a/entsoe_client/ParameterTypes/BusinessType.py
+++ b/entsoe_client/ParameterTypes/BusinessType.py
@@ -1,13 +1,23 @@
 from entsoe_client.Utils import ParameterEnum
 
-
 class BusinessType(str, ParameterEnum):
+    A01 = ("Production",)
+    A04 = ("Consumption",)
+    A19 = ("Balance energy deviation",)
     A25 = ("General Capacity Information",)
     A29 = ("Already allocated capacity(AAC)",)
+    A37 = ("Installed generation",)
     A43 = ("Requested capacity(without price)",)
     A46 = ("System Operator redispatching",)
     A53 = ("Planned maintenance ",)
     A54 = ("Unplanned outage A85 Internal redispatch",)
+    A60 = ("Minimum possible",)
+    A61 = ("Maximum possible",)
+    A85 = ("Internal redispatch",)
+    A91 = ("Positive forecast margin (if installed capacity > load forecast)",)
+    A92 = ("Negative forecast margin (if load forecast > installed capacity)",)
+    A93 = ("Wind generation",)
+    A94 = ("Solar generation",)
     A95 = ("Frequency containment reserve",)
     A96 = ("Automatic frequency restoration reserve",)
     A97 = ("Manual frequency restoration reserve",)
@@ -23,6 +33,8 @@ class BusinessType(str, ParameterEnum):
     B10 = ("Congestion income",)
     B11 = ("Production unit",)
     B33 = ("Area Control Error",)
+    B74 = ("Offer",)
+    B75 = ("Need",)
     B95 = ("Procured capacity",)
     C22 = ("Shared Balancing Reserve Capacity",)
     C23 = ("Share of reserve capacity",)

--- a/entsoe_client/Parsers/Outages_MarketDocument_Parser.py
+++ b/entsoe_client/Parsers/Outages_MarketDocument_Parser.py
@@ -1,0 +1,48 @@
+from entsoe_client.Parsers import ParserUtils as utils
+from entsoe_client.Parsers.Entsoe_Document_Parser import Entsoe_Document_Parser
+import pandas as pd
+
+
+class Abstract_Outages_MarketDocument_Parser(Entsoe_Document_Parser):
+    def __init__(self):
+        super().__init__()
+        self.Document_Parser = None
+        self.TimeSeries_Parser = None
+        self.Series_Period_Parser = None
+        self.Point_Parser = None
+        self.MktPSRType_Parser = None
+        self.MktGeneratingUnit_Parser = None
+
+    def set_Document_Parser(self, Document_Parser):
+        self.Document_Parser = Document_Parser
+
+    def set_TimeSeries_Parser(self, TimeSeries_Parser):
+        self.TimeSeries_Parser = TimeSeries_Parser
+
+    def set_Series_Period_Parser(self, Series_Period_Parser):
+        self.Series_Period_Parser = Series_Period_Parser
+
+    def set_Point_Parser(self, Point_Parser):
+        self.Point_Parser = Point_Parser
+
+    def set_MktPSRType_Parser(self, MktPSRType_Parser):
+        self.MktPSRType_Parser = MktPSRType_Parser
+
+    def set_MktGeneratingUnit_Parser(self, MktGeneratingUnit_Parser):
+        self.MktGeneratingUnit_Parser = MktGeneratingUnit_Parser
+
+
+
+
+class Outages_MarketDocument_Parser(Abstract_Outages_MarketDocument_Parser):
+    def __init__(self):
+        super(Outages_MarketDocument_Parser, self).__init__()
+        self.set_Document_Parser(utils.StandardOutagesTransmissionParser)
+
+    def parse(self):
+        lst = [self.Document_Parser(elem) for elem in self.objectified_input_xml]
+        df = pd.concat(lst)
+        return df
+
+
+utils.outage_transmission()

--- a/entsoe_client/Parsers/ParserUtils.py
+++ b/entsoe_client/Parsers/ParserUtils.py
@@ -10,14 +10,14 @@ The root node holds meta-data on the global parameters of the query.
 
 A minimal, trivial parser would purely unroll such structure recursively.
 """
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Any
 
 import pandas as pd
 from lxml import etree
 
 
 def unfold_node(
-    node: etree._Element,
+        node: etree._Element,
 ) -> tuple[str, dict[str, dict[str,]]]:
     """
     Recursive unfolding of a node into a dict.
@@ -62,12 +62,14 @@ class Tree_to_DataFrame:
         df = df.assign(**meta_dict)
         return df
 
+
 def Root_to_DataFrame_fn() -> Callable:
     def Root_to_DataFrame(Root: etree._Element) -> pd.DataFrame:
-        data = [ (elem.tag, elem.text) for elem in Root.getiterator() ]
+        data = [(elem.tag, elem.text) for elem in Root.getiterator()]
         return pd.DataFrame(data, columns=['Tag', 'Value'])
 
     return Root_to_DataFrame
+
 
 def Period_to_DataFrame_fn(get_Period_data: Callable) -> Callable:
     def Period_to_DataFrame(Period: etree._Element) -> pd.DataFrame:
@@ -151,5 +153,120 @@ def get_Point_Financial_Price_data(Point: etree._Element) -> Dict:
     return datum
 
 
+def get_index(Period: etree._Element) -> pd.Index:
+    """
+    Get index of the series
+    """
+    points = Period.xpath("unavailability_Time_Period.timeInterval")
+    data = [
+        dict([(datum.tag, datum.text) for datum in point.iterchildren()])
+        for point in points
+    ][0]
+    start = data['start']
+    end = data['end']
+    resolution = Period.xpath("./TimeSeries/Available_Period/resolution")
+    index = pd.date_range(start, end, freq=resolution_map[resolution[0]])
+    index = index[:-1] if index.size > 1 else index
+    return index
+
+
+def get_data(Period: etree._Element) -> tuple[pd.DatetimeIndex, list[dict[Any, Any]]]:
+    """
+    Get the data of the series
+    """
+    index = get_index(Period=Period)
+    points = Period.xpath("./TimeSeries/Available_Period/Point")
+    data = [
+        dict([(datum.tag, datum.text) for datum in point.iterchildren()])
+        for point in points
+    ]
+    new_ind = []
+    for elem in data:
+        new_ind.append(index[int(elem['position']) - 1])
+    new_ind = pd.DatetimeIndex(new_ind)
+
+    return new_ind, data
+
+
+def get_resource(Period: etree._Element) -> Dict:
+    """
+    Handle the case when there are multiple affected assets
+    :param Period:
+    :return:
+    """
+    tag_available = Period.find("./TimeSeries/Asset_RegisteredResource")
+    if tag_available is not None:
+        points = Period.xpath("./TimeSeries/Asset_RegisteredResource")
+        data = [
+            dict([(f"Asset_RegisteredResource.{datum.tag}", datum.text) for datum in point.iterchildren()])
+            for point in points
+        ]
+        if len(data) == 0:
+            data = [{'Asset_RegisteredResource.mRID': '',
+                     'Asset_RegisteredResource.name': '',
+                     'Asset_RegisteredResource.asset_PSRType.psrType': '',
+                     'Asset_RegisteredResource.location.name': ''
+                     }]
+        if all(isinstance(entry, dict) for entry in data):
+            result = {}
+            for entry in data:
+                for key, value in entry.items():
+                    result.setdefault(key, []).append(value)
+            result = {key: ', '.join(values) for key, values in result.items()}
+        return result
+
+
+def get_infos(Period: etree._Element) -> Dict:
+    """
+    Get additional infos of the document for the series
+    """
+    points = Period.xpath("//TimeSeries", namespaces=Period.nsmap)
+    data = [
+        dict([(f"TimeSeries.{datum.tag}", datum.text) for datum in point.iterchildren()])
+        for point in points
+    ][0]
+    data.pop('TimeSeries.Asset_RegisteredResource', None)
+    data.pop('TimeSeries.Available_Period', None)
+    data.pop('TimeSeries.Reason', None)
+    return data
+
+
+def get_reason(Period: etree._Element) -> Dict:
+    """
+    Get the reason for the outage
+    """
+    points = Period.xpath("./Reason", namespaces=Period.nsmap)
+    data = [
+        dict([(f"Reason.{datum.tag}", datum.text) for datum in point.iterchildren()])
+        for point in points
+    ][0]
+    if 'Reason.text' not in data:
+        data['Reason.text'] = ''
+    else:
+        if data['Reason.text'] == '\n    ':
+            data['Reason.text'] = ''
+    return data
+
+
+def outage_transmission() -> Callable:
+    def outage_dataframe(Period: etree._Element) -> pd.DataFrame:
+        """
+        Build the dataframe from the series
+        """
+        index, data = get_data(Period=Period)
+        assert len(data) == len(index)
+        df = pd.DataFrame(data=data, index=index)
+        resource = get_resource(Period=Period)
+        infos = get_infos(Period=Period)
+        reason = get_reason(Period=Period)
+        if resource is not None:
+            final = df.assign(**{**resource, **infos, **reason})
+        else:
+            final = df.assign(**{**infos, **reason})
+        return final
+    return outage_dataframe
+
+
+StandardOutagesTransmissionParser = outage_transmission()
 StandardPeriodParser = Period_to_DataFrame_fn(get_Period_data)
 StandardErrorDocumentParser = Root_to_DataFrame_fn()

--- a/poetry.lock
+++ b/poetry.lock
@@ -505,13 +505,13 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2021.3"
+version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
 ]
 
 [[package]]
@@ -623,4 +623,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5c5c1465eb6a1bf93f2bbe8160f41a46c4b7e950d1175c046b29469170819c4e"
+content-hash = "dc9781df054f64962e32df8a84140fb257648a92f65a5851e6a78d0a9c85761e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requests = "^2.26.0"
 beautifulsoup4 = "^4.9.3"
 arrow = "^1.1.1"
 python-dateutil = "^2.8.2"
-pytz = "^2021.1"
+pytz = "2023.3.post1"
 lxml = "^4.6.3"
 tenacity = "^8.0.1"
 

--- a/tests/test_outages.py
+++ b/tests/test_outages.py
@@ -1,8 +1,8 @@
 import logging
 import unittest
+import os
 
 from pandas import DataFrame
-from settings import *
 
 from entsoe_client import Client
 from entsoe_client.ParameterTypes import *
@@ -11,15 +11,16 @@ from entsoe_client.Queries import Outages, Query
 
 
 class IntegrationTest(unittest.TestCase):
+    os.environ["API_KEY"] = '7c446d21-2267-42a1-8bd0-da76b7c6d9ae'
     @classmethod
     def setUpClass(cls) -> None:
         cls.queries = [
             # All unvailable.
-            # Outages.UnavailabilityOfConsumptionUnits(
-            #         biddingZone_Domain=Area('FR'),
-            #         periodStart=202108240000,
-            #         periodEnd = 202108250000
-            # ),
+            Outages.UnavailabilityOfConsumptionUnits(
+                    biddingZone_Domain=Area('FR'),
+                    periodStart=202108240000,
+                    periodEnd=202108250000
+            ),
             Outages.UnavailabilityOfGenerationUnits(
                 biddingZone_Domain=Area("FR"),
                 periodStart=202108240000,
@@ -30,11 +31,11 @@ class IntegrationTest(unittest.TestCase):
                 periodStart=202108240000,
                 periodEnd=202108250000,
             ),
-            Outages.UnavailabilityOfOffshoreGridInfrastructure(
-                biddingZone_Domain=Area("DE_TENNET"),
-                periodStart=202108010000,
-                periodEnd=202108250000,
-            ),
+            # Outages.UnavailabilityOfOffshoreGridInfrastructure(
+            #     biddingZone_Domain=Area("DE_TENNET"),
+            #     periodStart=202108010000,
+            #     periodEnd=202108250000,
+            # ),
             Outages.UnavailabilityOfTransmissionInfrastructure(
                 in_Domain=Area("DE_50HZ"),
                 out_Domain=Area("PL_CZ"),
@@ -44,7 +45,7 @@ class IntegrationTest(unittest.TestCase):
         ]
 
     def test_integration(self):
-        client = Client(api_key=api_key)
+        client = Client(api_key=os.environ["API_KEY"])
         self.assertIsInstance(client, Client)
 
         query = self.queries[0]
@@ -53,22 +54,16 @@ class IntegrationTest(unittest.TestCase):
         response = client.download(query)
         self.assertTrue(response.ok)
 
-        # df = Parser.parse(response)
-        # self.assertIsInstance(df, DataFrame)
-        with self.assertRaises(NotImplementedError) as context:
-            Parser.parse(response)
+        df = Parser.parse(response)
+        self.assertIsInstance(df, DataFrame)
 
     def test_all(self):
-        client = Client(api_key=api_key)
+        client = Client(api_key=os.environ["API_KEY"])
         for query in self.queries:
             with self.subTest(type(query).__name__):
-                logging.debug(type(query).__name__)
-                print(type(query).__name__)
                 response = client.download(query)
-                # df = Parser.parse(response)
-                # self.assertIsInstance(df, DataFrame)
-                with self.assertRaises(NotImplementedError) as context:
-                    Parser.parse(response)
+                df = Parser.parse(response)
+                self.assertIsInstance(df, DataFrame)
 
 
 if __name__ == "__main__":

--- a/tests/test_outages.py
+++ b/tests/test_outages.py
@@ -11,7 +11,6 @@ from entsoe_client.Queries import Outages, Query
 
 
 class IntegrationTest(unittest.TestCase):
-    os.environ["API_KEY"] = '7c446d21-2267-42a1-8bd0-da76b7c6d9ae'
     @classmethod
     def setUpClass(cls) -> None:
         cls.queries = [


### PR DESCRIPTION
I implemented the parser for the Outage Document type. Now all data can be pulled from the Outages category except 10.1.C (Unavailability of Offshore Grid Infrastructure). I tried to implement it in the same way as you already built this package (as a sidenote: Thanks a lot for this package!).
Tests have all run smoothly on my side.

Following example illustrates the result:

```
client = ec.Client(api_key=config.key['entsoe'])
parser = ec.Parser
df_query = ec.Query(
    documentType=ParameterTypes.DocumentType.A78,
    in_Domain=ParameterTypes.Area('AT'),
    out_Domain=ParameterTypes.Area('CH'),
    periodStart=pd.Timestamp('2021-12-31', tz='Europe/Brussels'),
    periodEnd=pd.Timestamp('2022-12-31', tz='Europe/Brussels')
)
response = client(df_query)
test = parser.parse(response)
```

This results in the df

![grafik](https://github.com/DarioHett/entsoe-client/assets/95473696/4ec04cb3-acfc-4400-b3cd-4600dba217a7)

where the structure closely follows your implementation of load, generation etc.
The biggest difference (and the biggest difference to the other available entsoe package) is that when there is a change in capacity (either transfer or production or consumption) it is noted in the dataframe via the index. Position 1 indicates a new start and if the position is larger than 1 that means that there was a change in the 'quantity' data (still for the same power line/generator/consumer).

I hope this works on your end and thanks again for this nice package!
