### PR TITLE
Add Unavailability_MarketDocument_parser and fix ZipParser bug.

### DIFF
--- a/entsoe_client/Parsers/Unavailability_MarketDocument_parser.py
+++ b/entsoe_client/Parsers/Unavailability_MarketDocument_parser.py
@@ -1,0 +1,44 @@
+from entsoe_client.Parsers import ParserUtils as utils
+from entsoe_client.Parsers.Entsoe_Document_Parser import Entsoe_Document_Parser
+
+class Abstract_Unavailability_MarketDocument_Parser(Entsoe_Document_Parser):
+    def __init__(self):
+        super().__init__()
+        self.Document_Parser = None
+        self.TimeSeries_Parser = None
+        self.Series_Period_Parser = None
+        self.Point_Parser = None
+        self.MktPSRType_Parser = None
+        self.MktGeneratingUnit_Parser = None
+
+    def set_Document_Parser(self, Document_Parser):
+        self.Document_Parser = Document_Parser
+
+    def set_TimeSeries_Parser(self, TimeSeries_Parser):
+        self.TimeSeries_Parser = TimeSeries_Parser
+
+    def set_Series_Period_Parser(self, Series_Period_Parser):
+        self.Series_Period_Parser = Series_Period_Parser
+
+    def set_Point_Parser(self, Point_Parser):
+        self.Point_Parser = Point_Parser
+
+    def set_MktPSRType_Parser(self, MktPSRType_Parser):
+        self.MktPSRType_Parser = MktPSRType_Parser
+
+    def set_MktGeneratingUnit_Parser(self, MktGeneratingUnit_Parser):
+        self.MktGeneratingUnit_Parser = MktGeneratingUnit_Parser
+
+
+class Unavailability_MarketDocument_Parser(Abstract_Unavailability_MarketDocument_Parser):
+    def __init__(self):
+        super().__init__()
+        self.set_Document_Parser(
+            utils.Tree_to_DataFrame(utils.Root_to_DataFrame_fn(), "TimeSeries")
+        )
+
+    def parse(self):
+        df = self.Document_Parser(self.objectified_input_xml)
+        # Remove the metadata from the parent node (Timeseries) which does not give extra information
+        df = df.reset_index().pivot(columns="Tag", values="Value", index="Unavailability_MarketDocument.mRID")
+        return df


### PR DESCRIPTION
The Unavailability_MarketDocument_parser allows you to parse 4.7.6. Fall-backs (see [ENTSO-E API Guide](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)). 

I added checks in the ```ParserFactory``` to check the ```document_type``` for the ```Unavailability_MarketDocument``` tag. Please note that I added the ```document_type```s for the ```Outages_MarketDocument_Parser()``` to the best of my knowledge but cannot give a guarantee.

I further reverted the changes to the ```ZipParser``` that were introduced with commit https://github.com/DarioHett/entsoe-client/commit/0145930fc9dde975daad380ac07b58003062dcb1 . As it was implemented, the ```ZipParser``` was handing a ```list()```down to the ```XMLParser``` which caused an error. IMHO it is better to handle the occurrence of multiple zip files in the ```ZipParser``` directly.